### PR TITLE
Prevent failed jobs from clogging up redis if there is no availble connection

### DIFF
--- a/app/jobs/hyrax/hirmeos/hirmeos_file_updater_job.rb
+++ b/app/jobs/hyrax/hirmeos/hirmeos_file_updater_job.rb
@@ -2,6 +2,9 @@
 module Hyrax
   module Hirmeos
     class HirmeosFileUpdaterJob < ApplicationJob
+      # If there is no available connection, drop the job
+      discard_on Faraday::ConnectionFailed
+
       def perform(resource_id)
         resource = ActiveFedora::Base.find(resource_id)
         Hyrax::Hirmeos::MetricsTracker.new.submit_file_to_hirmeos(resource)

--- a/app/jobs/hyrax/hirmeos/hirmeos_registration_job.rb
+++ b/app/jobs/hyrax/hirmeos/hirmeos_registration_job.rb
@@ -2,6 +2,9 @@
 module Hyrax
   module Hirmeos
     class HirmeosRegistrationJob < ApplicationJob
+      # If there is no available connection, drop the job
+      discard_on Faraday::ConnectionFailed
+
       def perform(resource_id)
         resource = ActiveFedora::Base.find(resource_id)
         Hyrax::Hirmeos::MetricsTracker.new.submit_to_hirmeos(resource)

--- a/app/jobs/hyrax/hirmeos/hirmeos_work_updater_job.rb
+++ b/app/jobs/hyrax/hirmeos/hirmeos_work_updater_job.rb
@@ -2,6 +2,9 @@
 module Hyrax
   module Hirmeos
     class HirmeosWorkUpdaterJob < ApplicationJob
+      # If there is no available connection, drop the job
+      discard_on Faraday::ConnectionFailed
+
       def perform(resource_id)
         resource = ActiveFedora::Base.find(resource_id)
         service.submit_diff_to_hirmeos(resource)


### PR DESCRIPTION
This is mostly an issue for development whereby sidekiq log get really noisy with failed Hirmeos jobs getting stacked up and retying. 